### PR TITLE
Avoid KeyError when a bls directory is empty

### DIFF
--- a/ecleankernel/layout/blspec.py
+++ b/ecleankernel/layout/blspec.py
@@ -127,8 +127,9 @@ class BlSpecLayout(ModuleDirLayout):
                         self.name_map.get(fn, KernelFileType.MISC),
                         dir_path / fn,
                         k, ver, module_dict, exclusions)
-                kernels[(ver, "bls")].all_files.append(
-                    EmptyDirectory(dir_path))
+                if (ver, "bls") in kernels:
+                    kernels[(ver, "bls")].all_files.append(
+                        EmptyDirectory(dir_path))
 
         # collect from ESP/Linux
         if self.ukidir.is_dir():


### PR DESCRIPTION
If a bls directory is empty, eclean-kernel fails with a KeyError. This can happen when too many kernels build up and the /boot partition is filled to the point that writing the initramfs fails.

Fixes #60

e.g.
  File "/home/peter/eclean-kernel/.venv/bin/eclean-kernel", line 10, in <module>                                                                                                                    12:42 [54/433]
    sys.exit(setuptools_main())
             ~~~~~~~~~~~~~~~^^
  File "/home/peter/eclean-kernel/ecleankernel/__main__.py", line 391, in setuptools_main
    sys.exit(main(sys.argv[1:]))
             ~~~~^^^^^^^^^^^^^^
  File "/home/peter/eclean-kernel/ecleankernel/__main__.py", line 236, in main
    kernels = layout.find_kernels(exclusions=exclusions)
  File "/home/peter/eclean-kernel/ecleankernel/layout/blspec.py", line 130, in find_kernels
    kernels[(ver, "bls")].all_files.append(
    ~~~~~~~^^^^^^^^^^^^^^
KeyError: ('7.0.1-gentoo-dist', 'bls')